### PR TITLE
Added support to log content that do not have a valid Content-Type he…

### DIFF
--- a/CentauroTech.Utils.LogRequestHandler/CentauroTech.Utils.LogRequestHandler.csproj
+++ b/CentauroTech.Utils.LogRequestHandler/CentauroTech.Utils.LogRequestHandler.csproj
@@ -42,6 +42,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/CentauroTech.Utils.LogRequestHandler/RequestHandler.cs
+++ b/CentauroTech.Utils.LogRequestHandler/RequestHandler.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,7 +21,7 @@ namespace CentauroTech.Utils.LogRequestHandler
             set { _logger = value; }
         }
 
-        private Encoding _defaultEncoding
+        private Encoding DefaultEncoding
         {
             get
             {    
@@ -35,10 +36,6 @@ namespace CentauroTech.Utils.LogRequestHandler
                     encoding = Encoding.UTF8;
                 }
                 return encoding;
-            }
-            set
-            {
-                _defaultEncoding = value;
             }
         }
 
@@ -193,8 +190,9 @@ namespace CentauroTech.Utils.LogRequestHandler
         {
             var content = string.Empty;
             if (httpContent != null)
-                content = useDefaultEncoding ? _defaultEncoding.GetString(await httpContent.ReadAsByteArrayAsync()) :
-                                                await httpContent.ReadAsStringAsync();
+            {
+                content = useDefaultEncoding ? DefaultEncoding.GetString(await httpContent.ReadAsByteArrayAsync()) : await httpContent.ReadAsStringAsync();
+            }
             return content;
         }
     }

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ Add the message handler to the HttpConfiguration of you web site. The logs will 
       }
     }
 
-#### Config:
-Add a key CentauroTech.Utils.LogRequestHandler.DefaultEncoding in AppSettings to define a default encoding in case that the Content-Type header cannot been read.
+#### Config (Optional):
+Add a key CentauroTech.Utils.LogRequestHandler.DefaultEncoding in AppSettings to define a default encoding in case that the Content-Type header cannot be read or is invalid.
+```
 <appSettings>
   <add key="CentauroTech.Utils.LogRequestHandler.DefaultEncoding " value="UTF-8" />
 </appSettings>
-    
+```
 ##### log4net reference:
 https://logging.apache.org/log4net/

--- a/README.md
+++ b/README.md
@@ -36,5 +36,11 @@ Add the message handler to the HttpConfiguration of you web site. The logs will 
       }
     }
 
+#### Config:
+Add a key CentauroTech.Utils.LogRequestHandler.DefaultEncoding in AppSettings to define a default encoding in case that the Content-Type header cannot been read.
+<appSettings>
+  <add key="CentauroTech.Utils.LogRequestHandler.DefaultEncoding " value="UTF-8" />
+</appSettings>
+    
 ##### log4net reference:
 https://logging.apache.org/log4net/


### PR DESCRIPTION
Using ReadAsByteArrayAsync() instead of ReadAsStringAsync() to read content and obtaining the defaut encoding  through the appSettings key CentauroTech.Utils.LogRequestHandler.DefaultEncoding
